### PR TITLE
chore: bump playground version to 1.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opengrep-playground",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opengrep-playground",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opengrep-playground",
   "productName": "opengrep-playground",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Opengrep Playgorund Editor",
   "main": ".vite/build/main.js",
   "scripts": {


### PR DESCRIPTION
- update opengrep version to latest (1.4.1)