### PR TITLE
Add intrafile tainting toggle and editor file/clear actions

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,6 +5,10 @@
       <div class="column-view resizable">
         <div class="editor-header">
           <h3>Rule</h3>
+          <div class="editor-actions">
+            <button class="editor-action" @click="loadRuleFromFile" title="Load a YAML rule file from disk">Load file...</button>
+            <button class="editor-action editor-action--ghost" @click="clearRule" title="Clear the rule editor">Clear</button>
+          </div>
         </div>
         <div class="code-editor-container">
           <RuleEditor @ruleEditorUpdated="handleRuleEditorUpdate" />
@@ -16,6 +20,10 @@
       <div class="column-view resizable">
         <div class="editor-header">
           <h3>Code to Test</h3>
+          <div class="editor-actions">
+            <button class="editor-action" @click="loadCodeFromFile" title="Load a code file from disk">Load file...</button>
+            <button class="editor-action editor-action--ghost" @click="clearCode" title="Clear the code editor">Clear</button>
+          </div>
         </div>
         <div class="code-editor-container">
           <CodeEditor ref="codeEditor" @codeEditorUpdated="handleCodeEditorUpdate" />
@@ -50,6 +58,7 @@ const getSafeDir = inject('$getSafeDir');
 const joinPath = inject('$joinPath');
 const writeFile = inject('$writeFile');
 const showErrorDialog = inject('$showErrorDialog');
+const openFileDialog = inject('$openFileDialog');
 
 const codeEditor = ref(null);
 const resizingColumn = ref(null);
@@ -120,6 +129,50 @@ function stopResize() {
 function handleScrollToCodeSnippet(lineNumber) {
   if (codeEditor.value) {
     codeEditor.value.scrollToCodeSnippet(lineNumber)
+  }
+}
+
+function clearRule() {
+  // Setting the store empties the Monaco model via RuleEditor's watcher,
+  // which in turn disables the Evaluate button.
+  store.ruleEditorCode = { originalRule: '', normalizedRule: '' };
+}
+
+function clearCode() {
+  store.codeEditorCode = '';
+}
+
+async function loadRuleFromFile() {
+  await loadIntoEditor({
+    title: 'Load rule file',
+    filters: [{ name: 'YAML', extensions: ['yaml', 'yml'] }],
+    apply: (content) => {
+      store.ruleEditorCode = { originalRule: content, normalizedRule: content };
+    },
+  });
+}
+
+async function loadCodeFromFile() {
+  await loadIntoEditor({
+    title: 'Load code file',
+    filters: [{ name: 'All Files', extensions: ['*'] }],
+    apply: (content) => {
+      store.codeEditorCode = content;
+    },
+  });
+}
+
+async function loadIntoEditor({ title, filters, apply }) {
+  try {
+    const result = await openFileDialog({ title, filters });
+    if (!result || result.canceled) return;
+    if (result.error) {
+      showErrorDialog(`Error loading file: ${result.error}`, result.error);
+      return;
+    }
+    apply(result.content);
+  } catch (error) {
+    showErrorDialog(`Error loading file: ${error}`, error);
   }
 }
 </script>
@@ -197,6 +250,7 @@ $secondary-color: #2ecc71;
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: 8px;
 
     select {
       background-color: $primary-color;
@@ -207,6 +261,38 @@ $secondary-color: #2ecc71;
       cursor: pointer;
       outline: none;
       transition: background-color 0.3s ease;
+    }
+
+    .editor-actions {
+      display: flex;
+      gap: 6px;
+    }
+
+    .editor-action {
+      background-color: $primary-color;
+      color: white;
+      border: none;
+      border-radius: 4px;
+      padding: 4px 10px;
+      font-size: 11px;
+      font-family: inherit;
+      cursor: pointer;
+      transition: background-color 0.2s ease;
+
+      &:hover {
+        background-color: darken($primary-color, 8%);
+      }
+
+      &.editor-action--ghost {
+        background-color: transparent;
+        color: #555;
+        border: 1px solid #bdc3c7;
+
+        &:hover {
+          background-color: #ecf0f1;
+          color: #2c3e50;
+        }
+      }
     }
   }
 

--- a/src/components/RuleResults.vue
+++ b/src/components/RuleResults.vue
@@ -1,4 +1,21 @@
 <template>
+    <div class="scan-options">
+        <h3>Scan options</h3>
+        <label
+            class="taint-toggle"
+            :class="{ 'is-on': store.taintIntrafile }"
+            title="When ON, scans run with --taint-intrafile (intra-file taint analysis enabled).">
+            <input type="checkbox" v-model="store.taintIntrafile" />
+            <span class="taint-toggle__track">
+                <span class="taint-toggle__thumb"></span>
+            </span>
+            <span class="taint-toggle__label">
+                Intrafile tainting:
+                <strong>{{ store.taintIntrafile ? 'ON' : 'OFF' }}</strong>
+            </span>
+        </label>
+    </div>
+
     <div class="results-header">
         <h3>Results</h3>
         <button @click="handleRunBinary" :class="{ 'disabled': store.disableEvalButton }">Evaluate</button>
@@ -77,7 +94,7 @@
 </template>
 
 <script setup>
-import { inject, defineEmits, ref, onMounted } from 'vue';
+import { inject, defineEmits, ref, onMounted, watch } from 'vue';
 import { store } from '../store';
 
 const emit = defineEmits(['showDataFlows', 'scrollToCodeSnippet']);
@@ -95,17 +112,26 @@ onMounted(async () => {
     platform.value = await getPlatform();
 });
 
+// Invalidate stale results whenever a scan option changes — they no longer
+// reflect the current settings and would mislead the user.
+watch(() => store.taintIntrafile, () => {
+    clearResults();
+});
+
+function clearResults() {
+    store.jsonResult = {
+        scanResults: null,
+        testResults: null,
+        parsedTestResults: []
+    };
+}
 
 async function handleRunBinary() {
     if (!store.ruleEditorCode || store.disableEvalButton) return;
 
     isScanLoading.value = true;
     isTestLoading.value = true;
-    store.jsonResult = {
-        scanResults: null,
-        testResults: null,
-        parsedTestResults: []
-    }
+    clearResults();
 
     // Select correct binary based on OS
     let binaryPath = null
@@ -155,8 +181,11 @@ async function runBinaryForScan(binaryPath, runScanWithoutMatchingExplanations) 
         '--json',
         '--dataflow-traces',
         '--experimental',
-        '--taint-intrafile',
     ];
+
+    if (store.taintIntrafile) {
+        scanArgs.push('--taint-intrafile');
+    }
 
     if (!runScanWithoutMatchingExplanations) {
         scanArgs.push('--matching-explanations');
@@ -188,7 +217,11 @@ function extractScanErrors(jsonOutput) {
 async function runBinaryForTests(binaryPath) {
     const testArgs =
       ['scan --test', `-f "${store.ruleFilePath}" "${store.codeSampleFilePath}"`,
-       '--json', '--experimental', '--taint-intrafile'];
+       '--json', '--experimental'];
+
+    if (store.taintIntrafile) {
+        testArgs.push('--taint-intrafile');
+    }
 
     const testResponse = await runBinary(`"${binaryPath}"`, testArgs)
     const testResults = JSON.parse(testResponse.output);
@@ -226,6 +259,89 @@ function scrollToCodeSnippet(lineNumber) {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: 12px;
+}
+
+.scan-options {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid #e1e4e8;
+    margin-bottom: 8px;
+}
+
+.taint-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    user-select: none;
+    font-size: 12px;
+    font-family: monospace;
+    color: #555;
+
+    input[type="checkbox"] {
+        position: absolute;
+        opacity: 0;
+        width: 0;
+        height: 0;
+        pointer-events: none;
+    }
+
+    .taint-toggle__track {
+        position: relative;
+        display: inline-block;
+        width: 32px;
+        height: 18px;
+        background-color: #bdc3c7;
+        border-radius: 9px;
+        transition: background-color 0.2s ease;
+        flex-shrink: 0;
+    }
+
+    .taint-toggle__thumb {
+        position: absolute;
+        top: 2px;
+        left: 2px;
+        width: 14px;
+        height: 14px;
+        background-color: #fff;
+        border-radius: 50%;
+        transition: transform 0.2s ease;
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+    }
+
+    .taint-toggle__label strong {
+        font-weight: bold;
+        color: #7f8c8d;
+    }
+
+    &.is-on {
+        color: #2c3e50;
+
+        .taint-toggle__track {
+            background-color: #3498db;
+        }
+
+        .taint-toggle__thumb {
+            transform: translateX(14px);
+        }
+
+        .taint-toggle__label strong {
+            color: #2980b9;
+        }
+    }
+
+    &:hover .taint-toggle__track {
+        filter: brightness(0.95);
+    }
+
+    input[type="checkbox"]:focus-visible + .taint-toggle__track {
+        outline: 2px solid #3498db;
+        outline-offset: 2px;
+    }
 }
 
 .result-footer {

--- a/src/main.js
+++ b/src/main.js
@@ -175,6 +175,34 @@ app.whenReady().then(() => {
     return os.platform();
   });
 
+  // Open a native file picker and return the chosen file's contents.
+  // Returns { canceled: true } when the user dismisses the dialog.
+  ipcMain.handle("open-file-dialog", async (event, options = {}) => {
+    try {
+      const window = BrowserWindow.fromWebContents(event.sender);
+      const dialogOptions = {
+        properties: ['openFile'],
+        filters: options.filters || [{ name: 'All Files', extensions: ['*'] }],
+      };
+      if (options.title) dialogOptions.title = options.title;
+
+      const result = window
+        ? await dialog.showOpenDialog(window, dialogOptions)
+        : await dialog.showOpenDialog(dialogOptions);
+
+      if (result.canceled || result.filePaths.length === 0) {
+        return { canceled: true };
+      }
+
+      const filePath = result.filePaths[0];
+      const content = await fs.promises.readFile(filePath, 'utf-8');
+      return { canceled: false, filePath, content };
+    } catch (error) {
+      fs.writeFileSync(errorLogPath, `Error opening file dialog: ${error}\n\n`, { flag: 'a' });
+      return { error: error.message };
+    }
+  });
+
   ipcMain.handle("show-error-dialog", (event, errorMessage, error) => {
     try {
       if (!!error) {

--- a/src/preload.js
+++ b/src/preload.js
@@ -15,6 +15,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
   getSafeDir: () => ipcRenderer.invoke("get-safe-dir"),
   getRootDir: () => ipcRenderer.invoke("get-root-dir"),
   showErrorDialog: (errorMessage, error = null) => ipcRenderer.invoke("show-error-dialog", errorMessage, error),
+  openFileDialog: (options = {}) => ipcRenderer.invoke("open-file-dialog", options),
 });
 
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -29,6 +29,7 @@ app.provide('$readDir', window.electronAPI.readDir);
 app.provide('$removeDir', window.electronAPI.removeDir);
 app.provide('$runBinary', window.electronAPI.runBinary);
 app.provide('$showErrorDialog', window.electronAPI.showErrorDialog);
+app.provide('$openFileDialog', window.electronAPI.openFileDialog);
 
 self.MonacoEnvironment = {
   getWorker(_, label) {

--- a/src/store.js
+++ b/src/store.js
@@ -19,4 +19,5 @@ export const store = reactive({
     codeEditorDebugLocation: null,
     mustNotMatchTestCases: [],
     disableEvalButton: true,
+    taintIntrafile: true,
 });


### PR DESCRIPTION
## Summary
- New **Scan options** section above the results panel with an *Intrafile tainting* toggle that controls whether `--taint-intrafile` is passed to scan and test runs (defaults to ON to preserve existing behaviour). Flipping the toggle invalidates the current results so they cannot mislead.
- Each editor header (**Rule** and **Code to Test**) now has *Load file...* and *Clear* buttons. Load opens a native OS file picker via a new `open-file-dialog` IPC handler, restricted to `.yaml`/`.yml` for the rule editor and any file for the code editor. Clear empties the editor (and disables Evaluate when the rule is cleared).