### PR TITLE
Patch dependency advisories (dompurify, vite, tar, js-yaml)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@fortawesome/vue-fontawesome": "3.1.3",
         "@guolao/vue-monaco-editor": "1.6.0",
         "electron-squirrel-startup": "1.0.1",
-        "js-yaml": "4.1.1",
+        "js-yaml": "4.2.0",
         "monaco-yaml": "5.4.0",
         "vue": "3.5.26"
       },
@@ -33,7 +33,7 @@
         "@vitejs/plugin-vue": "6.0.3",
         "electron": "40.8.5",
         "sass-embedded": "1.97.2",
-        "vite": "7.3.2"
+        "vite": "7.3.5"
       },
       "engines": {
         "node": ">=22.12"
@@ -4157,9 +4157,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
-      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "peer": true,
       "optionalDependencies": {
@@ -6227,9 +6227,19 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -9062,9 +9072,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
-      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -9526,9 +9536,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@vitejs/plugin-vue": "6.0.3",
     "electron": "40.8.5",
     "sass-embedded": "1.97.2",
-    "vite": "7.3.2"
+    "vite": "7.3.5"
   },
   "keywords": [],
   "license": "MIT",
@@ -41,14 +41,14 @@
     "@fortawesome/vue-fontawesome": "3.1.3",
     "@guolao/vue-monaco-editor": "1.6.0",
     "electron-squirrel-startup": "1.0.1",
-    "js-yaml": "4.1.1",
+    "js-yaml": "4.2.0",
     "monaco-yaml": "5.4.0",
     "vue": "3.5.26"
   },
   "overrides": {
-    "tar": "7.5.13",
+    "tar": "7.5.16",
     "tmp": "0.2.7",
-    "dompurify": "3.4.0",
+    "dompurify": "3.4.11",
     "@tootallnate/once": "3.0.1",
     "@xmldom/xmldom": "0.8.13",
     "fast-uri": "3.1.2",


### PR DESCRIPTION
Resolves 12 Dependabot alerts by bumping four packages to their latest patched versions:

- dompurify 3.4.0 -> 3.4.11 (8 alerts: #111-117, #122)
- vite 7.3.2 -> 7.3.5 (2 alerts: #119 high, #121)
- tar 7.5.13 -> 7.5.16 (1 alert: #124)
- js-yaml 4.1.1 -> 4.2.0 (1 alert: #123)

dompurify and tar via `overrides`; vite and js-yaml are direct deps. `npm install` reports 0 vulnerabilities.