### PR TITLE
Harden run-binary IPC and drop unused read-file handler

### DIFF
--- a/src/components/RuleResults.vue
+++ b/src/components/RuleResults.vue
@@ -177,7 +177,8 @@ async function handleRunBinary() {
 async function runBinaryForScan(binaryPath, runScanWithoutMatchingExplanations) {
     const scanArgs = [
         'scan',
-        `-f "${store.ruleFilePath}" "${store.codeSampleFilePath}"`,
+        '-f', store.ruleFilePath,
+        store.codeSampleFilePath,
         '--json',
         '--dataflow-traces',
         '--experimental',
@@ -191,7 +192,7 @@ async function runBinaryForScan(binaryPath, runScanWithoutMatchingExplanations) 
         scanArgs.push('--matching-explanations');
     }
 
-    const scanResponse = await runBinary(`"${binaryPath}"`, scanArgs);
+    const scanResponse = await runBinary(binaryPath, scanArgs);
     if (scanResponse.errorOutput && !scanResponse.output) {
         throw new Error(scanResponse.errorOutput);
     }
@@ -216,14 +217,14 @@ function extractScanErrors(jsonOutput) {
 
 async function runBinaryForTests(binaryPath) {
     const testArgs =
-      ['scan --test', `-f "${store.ruleFilePath}" "${store.codeSampleFilePath}"`,
+      ['scan', '--test', '-f', store.ruleFilePath, store.codeSampleFilePath,
        '--json', '--experimental'];
 
     if (store.taintIntrafile) {
         testArgs.push('--taint-intrafile');
     }
 
-    const testResponse = await runBinary(`"${binaryPath}"`, testArgs)
+    const testResponse = await runBinary(binaryPath, testArgs)
     const testResults = JSON.parse(testResponse.output);
 
     const extractTestErrors = testResults.config_with_errors?.map(configError => configError.error) || [];

--- a/src/main.js
+++ b/src/main.js
@@ -55,7 +55,7 @@ app.whenReady().then(() => {
       fs.writeFileSync(infoLogPath, `Running binary: ${binaryPath} ${args}\n\n`, { flag: 'a' });
       console.log("Running binary:", binaryPath, args);
 
-      const child = spawn(binaryPath, args, { shell: true });
+      const child = spawn(binaryPath, args);
 
       let output = "";
       let errorOutput = "";
@@ -93,17 +93,6 @@ app.whenReady().then(() => {
     });
   });
 
-
-  // Handle file reading from the main process
-  ipcMain.handle("read-file", async (event, filePath) => {
-    try {
-      const data = await fs.promises.readFile(filePath, "utf-8");
-      return data;
-    } catch (error) {
-      fs.writeFileSync(errorLogPath, `Error reading file: ${error}\n\n`, { flag: 'a' });
-      return { error: error.message };
-    }
-  });
 
   // Handle file writing from the main process
   ipcMain.handle("write-file", async (event, filePath, content, options) => {

--- a/src/preload.js
+++ b/src/preload.js
@@ -6,7 +6,6 @@ contextBridge.exposeInMainWorld("electronAPI", {
   getPlatform: () => ipcRenderer.invoke("get-platform"),
   runBinary: (binaryPath, args) =>
     ipcRenderer.invoke("run-binary", binaryPath, args),
-  readFile: (filePath) => ipcRenderer.invoke("read-file", filePath),
   writeFile: (filePath, content, options) => ipcRenderer.invoke("write-file", filePath, content, options),
   removeFile: (filePath) => ipcRenderer.invoke("remove-file", filePath),
   readDir: (path) => ipcRenderer.invoke("read-dir", path),

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -22,7 +22,6 @@ app.provide('$getPlatform', window.electronAPI.getPlatform);
 app.provide('$getSafeDir', window.electronAPI.getSafeDir);
 app.provide('$getRootDir', window.electronAPI.getRootDir);
 app.provide('$joinPath', window.electronAPI.joinPath);
-app.provide('$readFile', window.electronAPI.readFile);
 app.provide('$writeFile', window.electronAPI.writeFile);
 app.provide('$removeFile', window.electronAPI.removeFile);
 app.provide('$readDir', window.electronAPI.readDir);


### PR DESCRIPTION
Fixes two security findings in the Electron main process.

**Command injection (Critical) — `src/main.js`**
- Removed `shell: true` from the `run-binary` `spawn` call so no shell interprets the command or its arguments.
- Updated `RuleResults.vue` to pass a proper argv array (each flag/path its own element) and an unquoted binary path. Paths with spaces are handled natively by `spawn`.

**Path traversal (High) — `src/main.js`**
- Removed the `read-file` IPC handler entirely, along with its `preload.js` bridge and `renderer.js` provide. It was exposed but never invoked by the renderer, so deleting it removes the attacker-reachable surface rather than guarding it. The native file-picker read (`open-file-dialog`) is unaffected.

Renderer builds clean; scanning and tests verified working in the running app.