### PR TITLE
Run opengrep via a hard-coded command in the main process

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -53,7 +53,6 @@ import DebugSection from './components/DebugSection.vue';
 import RuleEditor from './components/RuleEditor.vue';
 import { store } from './store';
 
-const getRootDir = inject('$getRootDir');
 const getSafeDir = inject('$getSafeDir');
 const joinPath = inject('$joinPath');
 const writeFile = inject('$writeFile');
@@ -67,7 +66,6 @@ const startWidth = ref(0);
 
 onMounted(async () => {
   store.safeDir = await getSafeDir();
-  store.rootDir = await getRootDir();
 });
 
 function handleShowDataFlows(dataFlows) {
@@ -84,7 +82,6 @@ async function handleCodeEditorUpdate() {
 
     const codeSampleFilePath = await joinPath(store.safeDir, "tmp", `untitled_code.${store.languageDetails?.extension}`);
     await writeFile(codeSampleFilePath, store.codeEditorCode, { flag: 'w' }); // 'w' flag to create or overwrite the file
-    store.codeSampleFilePath = codeSampleFilePath;
 
   } catch (error) {
     showErrorDialog(`Error saving code: ${error}`, error);

--- a/src/components/RuleResults.vue
+++ b/src/components/RuleResults.vue
@@ -94,23 +94,16 @@
 </template>
 
 <script setup>
-import { inject, ref, onMounted, watch } from 'vue';
+import { inject, ref, watch } from 'vue';
 import { store } from '../store';
 
 const emit = defineEmits(['showDataFlows', 'scrollToCodeSnippet']);
 
-const joinPath = inject('$joinPath');
-const runBinary = inject('$runBinary');
-const getPlatform = inject('$getPlatform');
+const runOpengrep = inject('$runOpengrep');
 const showErrorDialog = inject('$showErrorDialog');
 
 const isScanLoading = ref(false);
 const isTestLoading = ref(false);
-const platform = ref(null);
-
-onMounted(async () => {
-    platform.value = await getPlatform();
-});
 
 // Invalidate stale results whenever a scan option changes — they no longer
 // reflect the current settings and would mislead the user.
@@ -133,22 +126,9 @@ async function handleRunBinary() {
     isTestLoading.value = true;
     clearResults();
 
-    // Select correct binary based on OS
-    let binaryPath = null
-    switch (platform.value) {
-        case 'win32':
-            binaryPath = await joinPath(store.rootDir, 'bin', 'windows', 'opengrep-cli.exe');
-            break;
-        case 'darwin':
-            binaryPath = await joinPath(store.rootDir, 'bin', 'macos', 'opengrep-cli');
-            break;
-        default:
-            binaryPath = await joinPath(store.rootDir, 'bin', 'linux', 'opengrep-cli');
-    }
-
     // Run tests
     try {
-        await runBinaryForTests(binaryPath);
+        await runBinaryForTests();
     } catch (error) {
         console.error("Error running tests:", error);
         showErrorDialog(`Error running tests: Please consult the error.log file at ${store.safeDir}`, error);
@@ -159,7 +139,7 @@ async function handleRunBinary() {
     // Run scan with retrying incase of error
     let retryAttempted = true;
     try {
-        await runBinaryForScan(binaryPath, false);
+        await runBinaryForScan(false);
     } catch (error) {
         console.error("Error running scanning:", error);
         if (!retryAttempted) {
@@ -168,31 +148,18 @@ async function handleRunBinary() {
         }
 
         retryAttempted = false;
-        await runBinaryForScan(binaryPath, true);
+        await runBinaryForScan(true);
     } finally {
         isScanLoading.value = false;
     }
 }
 
-async function runBinaryForScan(binaryPath, runScanWithoutMatchingExplanations) {
-    const scanArgs = [
-        'scan',
-        '-f', store.ruleFilePath,
-        store.codeSampleFilePath,
-        '--json',
-        '--dataflow-traces',
-        '--experimental',
-    ];
-
-    if (store.taintIntrafile) {
-        scanArgs.push('--taint-intrafile');
-    }
-
-    if (!runScanWithoutMatchingExplanations) {
-        scanArgs.push('--matching-explanations');
-    }
-
-    const scanResponse = await runBinary(binaryPath, scanArgs);
+async function runBinaryForScan(runScanWithoutMatchingExplanations) {
+    const scanResponse = await runOpengrep('scan', {
+        extension: store.languageDetails?.extension,
+        taintIntrafile: store.taintIntrafile,
+        matchingExplanations: !runScanWithoutMatchingExplanations,
+    });
     if (scanResponse.errorOutput && !scanResponse.output) {
         throw new Error(scanResponse.errorOutput);
     }
@@ -215,16 +182,11 @@ function extractScanErrors(jsonOutput) {
     });
 }
 
-async function runBinaryForTests(binaryPath) {
-    const testArgs =
-      ['scan', '--test', '-f', store.ruleFilePath, store.codeSampleFilePath,
-       '--json', '--experimental'];
-
-    if (store.taintIntrafile) {
-        testArgs.push('--taint-intrafile');
-    }
-
-    const testResponse = await runBinary(binaryPath, testArgs)
+async function runBinaryForTests() {
+    const testResponse = await runOpengrep('test', {
+        extension: store.languageDetails?.extension,
+        taintIntrafile: store.taintIntrafile,
+    });
     const testResults = JSON.parse(testResponse.output);
 
     const extractTestErrors = testResults.config_with_errors?.map(configError => configError.error) || [];

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,37 @@ if (started) {
   app.quit();
 }
 
+// Resolve the bundled opengrep CLI for the current platform. The path is built
+// entirely here in the main process so the renderer can never choose which
+// executable is launched.
+const resolveOpengrepBinary = () => {
+  const rootDir = app.isPackaged ? process.resourcesPath : app.getAppPath();
+  switch (os.platform()) {
+    case 'win32':
+      return path.join(rootDir, 'bin', 'windows', 'opengrep-cli.exe');
+    case 'darwin':
+      return path.join(rootDir, 'bin', 'macos', 'opengrep-cli');
+    default:
+      return path.join(rootDir, 'bin', 'linux', 'opengrep-cli');
+  }
+};
+
+// Build the opengrep argument vector. The command verb, flags and file paths
+// are all fixed here; the renderer only selects the mode and a couple of
+// boolean toggles, so no renderer value is interpolated into the command.
+const buildOpengrepArgs = (mode, ruleFile, codeFile, options) => {
+  const args = mode === 'test'
+    ? ['scan', '--test', '-f', ruleFile, codeFile, '--json', '--experimental']
+    : ['scan', '-f', ruleFile, codeFile, '--json', '--dataflow-traces', '--experimental'];
+  if (options.taintIntrafile) {
+    args.push('--taint-intrafile');
+  }
+  if (mode === 'scan' && options.matchingExplanations) {
+    args.push('--matching-explanations');
+  }
+  return args;
+};
+
 const createWindow = () => {
   // Create the browser window.
   const primaryDisplay = screen.getPrimaryDisplay();
@@ -49,11 +80,31 @@ app.whenReady().then(() => {
   fs.writeFileSync(errorLogPath, '', { flag: 'w' });
   fs.writeFileSync(infoLogPath, '', { flag: 'w' });
 
-  // Handle running binaries from the main process
-  ipcMain.handle("run-binary", async (event, binaryPath, args = []) => {
+  // Handle running opengrep from the main process. The binary, command verb,
+  // flags and file paths are all resolved here; the renderer supplies only the
+  // mode, the code sample's file extension and a couple of boolean toggles, so
+  // no renderer-controlled value is ever used to choose or construct the
+  // command.
+  ipcMain.handle("run-opengrep", async (event, mode, options = {}) => {
     return new Promise((resolve, reject) => {
-      fs.writeFileSync(infoLogPath, `Running binary: ${binaryPath} ${args}\n\n`, { flag: 'a' });
-      console.log("Running binary:", binaryPath, args);
+      if (mode !== 'scan' && mode !== 'test') {
+        reject(new Error(`Invalid opengrep mode: ${mode}`));
+        return;
+      }
+      const { extension } = options;
+      if (typeof extension !== 'string' || !/^[A-Za-z0-9]+$/.test(extension)) {
+        reject(new Error('Invalid code sample extension'));
+        return;
+      }
+
+      const binaryPath = resolveOpengrepBinary();
+      const tmpDir = path.join(basePath, 'tmp');
+      const ruleFile = path.join(tmpDir, 'untitled_rule.yaml');
+      const codeFile = path.join(tmpDir, `untitled_code.${extension}`);
+      const args = buildOpengrepArgs(mode, ruleFile, codeFile, options);
+
+      fs.writeFileSync(infoLogPath, `Running opengrep: ${binaryPath} ${args.join(' ')}\n\n`, { flag: 'a' });
+      console.log("Running opengrep:", binaryPath, args);
 
       const child = spawn(binaryPath, args);
 
@@ -153,15 +204,6 @@ app.whenReady().then(() => {
   // Handle getting the root directory from the main process
   ipcMain.handle("get-safe-dir", () => {
     return path.join(basePath);
-  });
-
-  // Handle getting the root directory from the main process
-  ipcMain.handle("get-root-dir", () => {
-    return app.isPackaged ? process.resourcesPath : app.getAppPath();
-  });
-
-  ipcMain.handle("get-platform", () => {
-    return os.platform();
   });
 
   // Open a native file picker and return the chosen file's contents.

--- a/src/preload.js
+++ b/src/preload.js
@@ -3,16 +3,14 @@
 const { contextBridge, ipcRenderer } = require("electron");
 
 contextBridge.exposeInMainWorld("electronAPI", {
-  getPlatform: () => ipcRenderer.invoke("get-platform"),
-  runBinary: (binaryPath, args) =>
-    ipcRenderer.invoke("run-binary", binaryPath, args),
+  runOpengrep: (mode, options) =>
+    ipcRenderer.invoke("run-opengrep", mode, options),
   writeFile: (filePath, content, options) => ipcRenderer.invoke("write-file", filePath, content, options),
   removeFile: (filePath) => ipcRenderer.invoke("remove-file", filePath),
   readDir: (path) => ipcRenderer.invoke("read-dir", path),
   removeDir: (path) => ipcRenderer.invoke("remove-dir", path),
   joinPath: (...segments) => ipcRenderer.invoke("join-path", ...segments),
   getSafeDir: () => ipcRenderer.invoke("get-safe-dir"),
-  getRootDir: () => ipcRenderer.invoke("get-root-dir"),
   showErrorDialog: (errorMessage, error = null) => ipcRenderer.invoke("show-error-dialog", errorMessage, error),
   openFileDialog: (options = {}) => ipcRenderer.invoke("open-file-dialog", options),
 });

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -18,15 +18,13 @@ library.add(far);
 app.component('font-awesome-icon', FontAwesomeIcon);
 
 app.provide('$electronAPI', window.electronAPI);
-app.provide('$getPlatform', window.electronAPI.getPlatform);
 app.provide('$getSafeDir', window.electronAPI.getSafeDir);
-app.provide('$getRootDir', window.electronAPI.getRootDir);
 app.provide('$joinPath', window.electronAPI.joinPath);
 app.provide('$writeFile', window.electronAPI.writeFile);
 app.provide('$removeFile', window.electronAPI.removeFile);
 app.provide('$readDir', window.electronAPI.readDir);
 app.provide('$removeDir', window.electronAPI.removeDir);
-app.provide('$runBinary', window.electronAPI.runBinary);
+app.provide('$runOpengrep', window.electronAPI.runOpengrep);
 app.provide('$showErrorDialog', window.electronAPI.showErrorDialog);
 app.provide('$openFileDialog', window.electronAPI.openFileDialog);
 

--- a/src/store.js
+++ b/src/store.js
@@ -6,11 +6,9 @@ export const store = reactive({
         testResults: null,
         parsedTestResults: [],
     },
-    rootDir: '',
     safeDir: '',
     languageDetails: null,
     ruleFilePath: '',
-    codeSampleFilePath: '',
     ruleEditorCode: {
         originalRule: '',
         normalizedRule: ''


### PR DESCRIPTION
Fixes the Aikido command-injection finding on `spawn` in `src/main.js`.

- The main process now resolves the opengrep binary, command verb, flags and rule/code file paths. The renderer sends only a mode (`scan`/`test`) and options (`extension`, `taintIntrafile`, `matchingExplanations`) over a new `run-opengrep` IPC, replacing `run-binary`. `mode` is validated against an allowlist and `extension` against `^[A-Za-z0-9]+$`; `spawn` runs with no shell.
- Removed the now-unused `get-platform` and `get-root-dir` IPC chains and the orphaned `rootDir` / `codeSampleFilePath` store fields.