### PR TITLE
Set least-privilege GITHUB_TOKEN permissions in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,13 @@ on:
         branches:
             - "**"
 
+permissions: {}
+
 jobs:
     build-windows:
         runs-on: windows-latest
+        permissions:
+            contents: read
         steps:
             - name: Checkout Repository
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -69,6 +73,8 @@ jobs:
 
     build-macos:
         runs-on: macos-latest
+        permissions:
+            contents: read
         steps:
             - name: Checkout Repository
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -130,6 +136,8 @@ jobs:
 
     build-linux:
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
         steps:
             - name: Checkout Repository
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/rolling-release.yaml
+++ b/.github/workflows/rolling-release.yaml
@@ -12,12 +12,13 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   build-windows:
     runs-on: windows-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -85,6 +86,8 @@ jobs:
 
   build-macos:
     runs-on: macos-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -158,6 +161,8 @@ jobs:
 
   build-linux:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -241,6 +246,8 @@ jobs:
   release:
     needs: [build-windows, build-macos, build-linux]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
Fixes the Aikido excessive-workflow-permissions finding on `.github/workflows/rolling-release.yaml`.

- `rolling-release.yaml`: set workflow-level `permissions: {}`; `build-windows`/`build-macos`/`build-linux` get `contents: read`; `release` gets `contents: write`.
- `build.yml`: added workflow-level `permissions: {}`; the three build jobs get `contents: read`.